### PR TITLE
Change the versions in Cargo.toml to indicate this is a fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web3"
-version = "0.10.0"
+version = "0.10.0-graph"
 description = "Ethereum JSON-RPC client."
 homepage = "https://github.com/tomusdrw/rust-web3"
 repository = "https://github.com/tomusdrw/rust-web3"


### PR DESCRIPTION
Add `-graph` to all versions so that there is no ambiguity between this fork and upstream. This seems to be the key to getting around a very annoying [issue](https://github.com/rust-analyzer/rust-analyzer/issues/6407) with `rust-analyzer` where it complains about missing imports from this fork.
